### PR TITLE
fix: wrong search patterns in getLogIP() function

### DIFF
--- a/src/bearDropper.sh
+++ b/src/bearDropper.sh
@@ -110,10 +110,9 @@ getLogTime () {
 # extra validation, fails safe. Args: $1=log line
 getLogIP () { 
   local logLine="$1"
-  local ebaPID=$(echo "$logLine" | sed -n 's/^.*authpriv.warn \(dropbear\[[0-9]*\]:\) Login attempt for nonexistent user.*/\1/p')
+  local ebaPID=$(echo "$logLine" | sed -n 's/^.*authpriv.info \(dropbear\[[0-9]*\]:\) Exit before auth.*/\1/p')
   [ -n "$ebaPID" ] && logLine=$($cmdLogreadEba | grep -F "${ebaPID} Child connection from ")
   echo "$logLine" | sed -n \
-    -e 's/[<>]//g;s/: Exited.*//;s/: [^:]*$//' \
     -e 's/^.*[^0-9]\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' \
     -e 's/^.*[^0-9a-f]\([0-9a-f]*:[0-9a-f]*:[0-9a-f]*:[0-9a-f]*:[0-9a-f]*:[0-9a-f]*:[0-9a-f]*:[0-9a-f]*\):.*/\1/p'
 }


### PR DESCRIPTION
Unsuccessful login log example without such patterns:
```
Wed Mar 26 05:31:04 2025 authpriv.info dropbear[11543]: Child connection from 45.79.181.104:6930
Wed Mar 26 05:31:04 2025 authpriv.info dropbear[11543]: Exit before auth from <45.79.181.104:6930>: No matching algo hostkey
```